### PR TITLE
borg-initialize: Number of skipped packets is number not vector.

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -267,7 +267,7 @@ is skipped."
              initialized
              (float-time (time-subtract (current-time) start))
              (if (> skipped 0)
-                 (format ", %d skipped" (length skipped))
+                 (format ", %d skipped" skipped)
                ""))))
 
 (defun borg-activate (drone)


### PR DESCRIPTION
Hello, if using skipped entries borg-initialize gives error because skipped is printed as vector not number.
With kind regards,
Stefan