### PR TITLE
Add support for Nix

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -344,12 +344,10 @@ This function is to be used only with `--batch'."
 
 (defun borg-run-build-steps-shell (drone)
   "Run the build-steps for DRONE, if it has any, as shell commands."
-  (let ((default-directory (borg-worktree drone))
-        (build (borg-get-all drone "build-step")))
-    (when build
-        (dolist (cmd build)
-          (borg-build-step cmd)
-          (message "  Running '%s'...done" cmd)))))
+  (let ((default-directory (borg-worktree drone)))
+    (dolist (cmd (borg-get-all drone "build-step"))
+      (borg-build-step cmd)
+      (message "  Running '%s'...done" cmd))))
 
 (defun borg-run-build-steps-nix-shell (drone)
   "Run the build-steps for DRONE, if it has any, on a nix-shell.

--- a/borg.el
+++ b/borg.el
@@ -392,30 +392,30 @@ then also activate the drone using `borg-activate'."
   (let ((default-directory (borg-worktree drone))
         (build-cmd (funcall borg-build-command drone))
         (build (borg-get-all drone "build-step")))
-    (when build
+    (if build
         (dolist (cmd build)
           (if (string-match-p "\\`(" cmd)
               (eval (read cmd))
             (when-let ((fcmd (funcall build-cmd cmd)))
               (message "  Running '%s'..." fcmd)
-              (shell-command fcmd))))))
+              (shell-command fcmd))))
 
-  ;; Then the standard build operations.
-  (let ((path (mapcar #'file-name-as-directory (borg-load-path drone))))
-    (if noninteractive
-        (progn (borg-update-autoloads drone path)
-               (borg-byte-compile drone path)
-               (borg-makeinfo drone))
-      (let ((process-connection-type nil))
-        (start-process
-         (format "Build %s" drone)
-         (generate-new-buffer (format "*Build %s*" drone))
-         (expand-file-name invocation-name invocation-directory)
-         "--batch" "-Q"
-         "-L" (borg-worktree "borg")
-         "--eval" "(require 'borg)"
-         "--eval" "(borg-initialize)"
-         "--eval" (format "(borg-build %S)" drone)))))
+      ;; Then the standard build operations.
+      (let ((path (mapcar #'file-name-as-directory (borg-load-path drone))))
+        (if noninteractive
+            (progn (borg-update-autoloads drone path)
+                   (borg-byte-compile drone path)
+                   (borg-makeinfo drone))
+          (let ((process-connection-type nil))
+            (start-process
+             (format "Build %s" drone)
+             (generate-new-buffer (format "*Build %s*" drone))
+             (expand-file-name invocation-name invocation-directory)
+             "--batch" "-Q"
+             "-L" (borg-worktree "borg")
+             "--eval" "(require 'borg)"
+             "--eval" "(borg-initialize)"
+             "--eval" (format "(borg-build %S)" drone)))))))
   (when activate
     (borg-activate drone)))
 

--- a/borg.el
+++ b/borg.el
@@ -351,6 +351,31 @@ This function is to be used only with `--batch'."
           (borg-build-step cmd)
           (message "  Running '%s'...done" cmd)))))
 
+(defun borg-run-build-steps-nix-shell (drone)
+  "Run the build-steps for DRONE, if it has any, on a nix-shell.
+
+The nix-shell is started with the file at
+submodules.DRONE.build-nix-shell-file or the packages at
+submodules.DRONE.build-nix-shell-packages.  If none of this is
+provided, and the package has no default.nix, it is run with the
+-p argument.  If there's a default.nix or shell.nix, no extra
+arguments are added."
+  (let ((build (borg-get-all drone "build-step"))
+        (nix-shell-args (or
+                         (when-let ((nix-shell-file (car (borg-get drone "build-nix-shell-file")))) nix-shell-file)
+                         (when-let ((nix-shell-pkgs (car (borg-get drone "build-nix-shell-packages")))) (concat "-p " nix-shell-pkgs))
+                         (unless
+                             (or
+                              (file-exists-p (expand-file-name "default.nix" default-directory))
+                              (file-exists-p (expand-file-name "shell.nix" default-directory)))
+                           "-p")
+                         "")))
+    (when build
+      (message "Building %s from nix-shell %s" drone nix-shell-args)
+      (dolist (cmd build)
+        (borg-build-step cmd
+                         (lambda (cmd) (shell-command (concat "nix-shell --run " cmd " " nix-shell-args))))))))
+
 (defvar borg-run-build-steps-function
   'borg-run-build-steps-shell
   "The command to run the build-steps for a drone.


### PR DESCRIPTION
This is a follow-up to #10 which adds support for running `build-step`s in a `nix-shell` environment.  It is made of two commits:

 - The first commit decouples the build-steps logic from `borg-build` and replace it with a `borg-run-build-steps-shell` function, which can be replaced by the user by setting the new variable `borg-run-build-steps-function`.  It also introduces an helper function `borg-build-step` which takes a string and an optional function (defaulting to `shell-command`) and executes the string through this function unless it looks like elisp (starts with a "("), in which case in `(eval)`uates it.  This is meant to keep the logic consistent between the default handler, provided, and user-provided handlers.

 - The second commit adds a `borg-run-build-steps-nix-shell` function, which wraps build-steps into a `nix-shell` configured through `submodules.DRONE.build-nix-shell-file` or `submodules.DRONE.build-nix-shell-packages`.  If none of these keys are set, it tries to automatically determine the best way to run the shell by checking if `shell.nix` or `default.nix` are present, in which case it passes no extra parameters, otherwise it just add an empty package list with `-p`.

I hope my Elisp isn't too bad, and reviewing it won't take you too much time.

Thanks 