### PR TITLE
Fix completion for borg-build and borg-activate.

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -282,7 +282,7 @@ is skipped."
 Add the appropriate directories to `load-path' and
 `Info-directory-alist', and load the autoloaads file, if it
 exists."
-  (interactive (list (completing-read "Activate drone: " (borg-drones) nil t)))
+  (interactive (list (borg-read-clone "Activate drone: ")))
   (dolist (dir (borg-load-path drone))
     (let (file)
       (cond ((and (file-exists-p
@@ -353,8 +353,7 @@ This function is to be used only with `--batch'."
   "Build the drone named DRONE.
 Interactively, or when optional ACTIVATE is non-nil,
 then also activate the drone using `borg-activate'."
-  (interactive (list (completing-read "Build drone: " (borg-drones) nil t)
-                     t))
+  (interactive (list (borg-read-clone "Build drone: ") t))
   (if noninteractive
       (let ((default-directory (borg-worktree drone))
             (build-cmd (if (functionp borg-build-shell-command)


### PR DESCRIPTION
This commit allows to interactively build and activate clones as well as drones.  Previously, interactive completion for borg `borg-build` and `borg-activate` required a valid drone name as parameter.