### PR TITLE
Fix submodule name regex

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -178,7 +178,7 @@ included in the returned value."
         (dolist (line (process-lines "git" "config" "--list"
                                      "--file" borg-gitmodules-file))
           (when (string-match
-                 "\\`submodule\\.\\([^.]+\\)\\.\\([^=]+\\)=\\(.+\\)\\'" line)
+                 "\\`submodule\\.\\(.+\\)\\.\\([^=]+\\)=\\(.+\\)\\'" line)
             (let* ((drone (match-string 1 line))
                    (prop  (intern (match-string 2 line)))
                    (value (match-string 3 line))


### PR DESCRIPTION
Don't stop catching the name after the first "." as submodule names
may contain a dot.

I wanted to assimilate my package `brain.fm` and saw that it sets the wrong `load-path` for it.
Not sure if there was a reason to parse the name only till the first dot but with this fix
my module and all 239 others in my collection are working fine.