### PR TITLE
Use new configuration files ~/.emacs.d/etc/borg/borg.{el,mk}

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,12 @@
   functionality iteratively and to create configurations that are not
   based on the Emacs.d collective.
 
+- The new user configuration files ~~/.emacs.d/etc/borg/config.el~ and
+  ~~/.emacs.d/etc/borg/config.mk~ are loaded by ~borg-build~ and ~make~ if
+  they exist.  These files are primarily intended to set the variables
+  ~borg-emacs-argument~ (which see) and ~EMACS_ARGUMENTS~.  The latter can
+  also be used to set ~EMACS~ and/or to define new make targets.
+
 - The new command ~borg-insert-update-message~ inserts information
   about drones that are updated in the index.  The inserted text is
   formatted according to the commit message conventions documented

--- a/borg.mk
+++ b/borg.mk
@@ -3,7 +3,10 @@
 # Author: Jonas Bernoulli <jonas@bernoul.li>
 # License: GPL v3 <https://www.gnu.org/licenses/gpl-3.0.txt>
 
-EMACS ?= emacs
+-include ../../etc/borg/config.mk
+
+EMACS           ?= emacs
+EMACS_ARGUMENTS ?= -Q
 
 .PHONY: all help clean build build-init quick bootstrap
 .FORCE:
@@ -35,30 +38,35 @@ clean:
 
 build:
 	@rm -f init.elc
-	@$(EMACS) -Q --batch -L lib/borg --load borg $(SILENCIO) \
+	@$(EMACS) $(EMACS_ARGUMENTS) \
+	--batch -L lib/borg --load borg $(SILENCIO) \
 	--funcall borg-initialize \
 	--funcall borg-batch-rebuild 2>&1
 
 build-init:
 	@rm -f init.elc
-	@$(EMACS) -Q --batch -L lib/borg --load borg \
+	@$(EMACS) $(EMACS_ARGUMENTS) \
+	--batch -L lib/borg --load borg \
 	--funcall borg-initialize \
 	--funcall borg-batch-rebuild-init 2>&1
 
 tangle-init: init.el
 init.el: init.org
-	@$(EMACS) -Q --batch --load org \
+	@$(EMACS) $(EMACS_ARGUMENTS) \
+	--batch --load org \
 	--eval '(org-babel-tangle-file "init.org")' 2>&1
 
 quick:
 	@rm -f init.elc
-	@$(EMACS) -Q --batch -L lib/borg --load borg $(SILENCIO) \
+	@$(EMACS) $(EMACS_ARGUMENTS) \
+	--batch -L lib/borg --load borg $(SILENCIO) \
 	--funcall borg-initialize \
 	--eval  '(borg-batch-rebuild t)' 2>&1
 
 lib/borg/borg.mk: ;
 lib/%: .FORCE
-	@$(EMACS) -Q --batch -L lib/borg --load borg $(SILENCIO) \
+	@$(EMACS) $(EMACS_ARGUMENTS) \
+	--batch -L lib/borg --load borg $(SILENCIO) \
 	--funcall borg-initialize \
 	--eval  '(borg-build "$*")' 2>&1
 


### PR DESCRIPTION
This is just a draft.

----

The paths conform to what the `no-littering` package would use.

Add variables `borg-emacs-arguments` and `EMACS_ARGUMENTS` to be set in those files.  "borg.mk" can also be used to set "EMACS".

The main use-case is to replace "-Q" with e.g. just "-q", but these variables could also be used to add additional "--eval" expressions.