### PR TITLE
Replace echo by the more portable printf

### DIFF
--- a/borg.sh
+++ b/borg.sh
@@ -19,7 +19,7 @@ do
     then
         name=$(git submodule--helper name "$path")
 
-        echo "\n--- [$name] ---\n"
+        printf "\n--- [%s] ---\n\n" $name
 
         if ! test -e "$path"/.git
         then


### PR DESCRIPTION
The default behaviour of bash's echo on Arch Linux seems to be to not
interpret backslash escapes like "\n". It prints them verbatim.

  checkbashism --posix borg.sh

complains about the backslash escapes in:

  echo "\n--- [$name] ---\n"

It does not complain at all and returns 0 when the echo statement is
replaced by the analogous printf statement.