### PR TITLE
Fix order of operations in borg.sh

### DIFF
--- a/borg.sh
+++ b/borg.sh
@@ -5,12 +5,16 @@
 # Author: Jonas Bernoulli <jonas@bernoul.li>
 # License: GPL v3 <https://www.gnu.org/licenses/gpl-3.0.txt>
 
+borg=$(dirname $0)
+test -n "$borg" || exit 2
+cd $borg || exit 2
+
+toplevel=$(git rev-parse --show-superproject-working-tree)
+test -n "$toplevel" || exit 2
+cd $toplevel || exit 2
+
 hive_remote=$(git config -f .gitmodules borg.collective)
 push_remote=$(git config -f .gitmodules borg.pushDefault)
-
-toplevel=$(git rev-parse --show-toplevel)
-test -n "$toplevel" || exit 2
-cd "$toplevel"
 
 git submodule--helper list |
 while read mode sha1 stage path


### PR DESCRIPTION
Problem: If 'git config -f .gitmodules xy' is run in a directory other
than the toplevel of the collective (where the proper .gitmodules
resides), it silently returns nothing. That way the behavior of
borg.sh differs depending on where it is started from.

The probably most beautiful solution would be to turn the initial
cd stuff into a sanity check / assertion: borg.sh should be
started only when we are in the toplevel of the corresponding
collective. But I do not know of a portable way to make that
work.

(Consider hard links above the toplevel of a collective. Then the
toplevel may have several "canonical" paths. A way to deal with
them would be to compare inode numbers. But I do not know if
every filesystem has (something like) inode numbers.)