### PR TITLE
Fix clean target.

### DIFF
--- a/borg.mk
+++ b/borg.mk
@@ -31,7 +31,7 @@ help:
 	@printf "\n"
 
 clean:
-	@find -name '*.elc' -exec rm '{}' ';'
+	@find . -name '*.elc' -exec rm '{}' ';'
 
 build:
 	@rm -f init.elc


### PR DESCRIPTION
The find program requires a path to operate as first argument on BSD
like systems (e.g. macOS). This way the clean target works on
GNU/Linux and also on BSD.