### PR TITLE
Fix borg build shell command

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -413,8 +413,8 @@ then also activate the clone using `borg-activate'."
                        (require 'format-spec)
                        (shell-command
                         (format-spec build-cmd
-                                     `((%s . ,cmd)
-                                       (%S . ,(shell-quote-argument cmd)))))))
+                                     `((?s . ,cmd)
+                                       (?S . ,(shell-quote-argument cmd)))))))
                     (t
                      (shell-command cmd)))
               (message "  Running '%s'...done" cmd))

--- a/borg.el
+++ b/borg.el
@@ -454,11 +454,13 @@ then also activate the clone using `borg-activate'."
   (package-activate 'borg)
   (require 'borg-elpa)
   (borg-elpa-initialize)
-  (borg-build %S))" user-emacs-directory clone)
+  (setq borg-build-shell-command (quote %S))
+  (borg-build %S))" user-emacs-directory borg-build-shell-command clone)
                    (format "(progn
   (require 'borg)
   (borg-initialize)
-  (borg-build %S))" clone)))
+  (setq borg-build-shell-command (quote %S))
+  (borg-build %S))" borg-build-shell-command clone)))
        'borg-build--process-filter)))
   (when activate
     (borg-activate clone)))


### PR DESCRIPTION
This is an attempt at fixing #57.   It simply passes the value of `borg-build-shell-command` to the child process.  If this value is a function, it should be registered as an autoload.

The changes in this PR are a superset of those in #58.  #58 is a strict bug fix (I hope :)), this one is a bit more opinionated.