### PR TITLE
Make `borg-silencio' hygienic

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -281,12 +281,13 @@ is used when reading the package name."
 (defmacro borg-silencio (regexp &rest body)
   "Execute the forms in BODY while silencing messages that don't match REGEXP."
   (declare (indent 1))
-  `(let ((msg (symbol-function 'message)))
-     (cl-letf (((symbol-function 'message)
-                (lambda (format-string &rest args)
-                  (unless (string-match-p ,regexp format-string)
-                    (apply msg format-string args)))))
-       ,@body)))
+  (let ((msg (make-symbol "msg")))
+    `(let ((,msg (symbol-function 'message)))
+       (cl-letf (((symbol-function 'message)
+                  (lambda (format-string &rest args)
+                    (unless (string-match-p ,regexp format-string)
+                      (apply ,msg format-string args)))))
+         ,@body))))
 
 ;;; Activation
 


### PR DESCRIPTION
Currently the implementation of `borg-silencio` is not hygienic meaning that if the body of `borg-silencio` let-bound a variable called `msg` (when lexical binding is disabled) or use `setq` to set the value of a variable called `msg`, `borg-silencio` can fails or have an unexpected behaviour. This pull request makes `borg-silencio`.

For example, this code fails with the current implementation (lexical binding is disabled):
```elisp
(borg-silencio "foo"
  (let ((msg "bar"))
    (message "baz")))
``` 