### PR TITLE
Require subr-x at compile time

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -51,10 +51,11 @@
 (require 'bytecomp)
 (require 'cl-lib)
 (require 'info)
-(require 'subr-x)
 
 (eval-when-compile
+  (require 'subr-x)
   (require 'epkg nil t))
+
 (declare-function eieio-oref        "eieio-core" (obj slot))
 (declare-function epkg                    "epkg" (name))
 (declare-function epkgs                   "epkg" (&optional select predicates))


### PR DESCRIPTION
if/when-let are macros and the byte compiler can expand these at
compile time. No need to load subr-x at run time.
