### PR TITLE
borg--maybe-absorb-gitdir: Support arbitrary version suffixes

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -863,9 +863,9 @@ Formatting is according to the commit message conventions."
 ;;; Internal Utilities
 
 (defun borg--maybe-absorb-gitdir (pkg)
-  (let ((ver (nth 2 (split-string (car (process-lines "git" "version")) " "))))
-    (when (string-match "\\.windows\\.[0-9]+\\'" ver)
-      (setq ver (substring ver 0 (match-beginning 0))))
+  (let* ((ver (nth 2 (split-string (car (process-lines "git" "version")) " ")))
+         (ver (and (string-match "\\`[0-9]+\\(\\.[0-9]+\\)*" ver)
+                   (match-string 0 ver))))
     (if (version< ver "2.12.0")
         (let ((gitdir (borg-gitdir pkg))
               (topdir (borg-worktree pkg)))


### PR DESCRIPTION
The Git version installed on a workstation I use Emacs on is of the form "2.32.0.272.[commit-hash]-[branch-name]" and causes `borg--maybe-absorb-gitdir` to report the error "Invalid version syntax: ‘2.32.0.272.[commit-hash]-[branch-name]’".

I noticed the change [borg--maybe-absorb-gitdir: Support version suffix on Windows](https://github.com/emacscollective/borg/commit/91668945db55e6c96940be1b49a868bd815b5e51) whitelisted a similar suffix and figured I might instead keep as much from the beginning of the version as possible instead.

Apologies for the `string-match` cruft in this change. It feels like there should be a cleaner way to accomplish what I'm going for, but I'm not aware of it at the moment.


