### PR TITLE
Fix submodule tracking for non-default branch

### DIFF
--- a/borg.sh
+++ b/borg.sh
@@ -69,7 +69,11 @@ do
 
         if test -e "$path"/.git
         then
+            branch=$(git submodule--helper remote-branch "$path")
             cd "$path"
+            # FIXME figure out the correct remote if there are multiple
+            remote=$(git remote | head -n 1)
+            git switch --force-create "$branch" "$remote/$branch"
             if ! git reset --hard "$sha1"
             then
                 echo >&2 "futile: Checkout of '$sha1' into submodule path '$path' failed"


### PR DESCRIPTION
This is a rough starting point to make submodules correctly track a non-default branch. A couple caveats that I couldn't figure out:
1. Notice the FIXME. I don't have any branches with multiple remotes specified, so I'm not able to test how this works with the logic that loops through `git config -f .gitmodules --get-all submodule."$name".remote` (lines 33-69). I took a wild guess with `head -n 1` to grab the first remote if there are multiple, but that's probably not right. 
2. I basically muddled my way around via internet research and reading git man pages, so while this works I doubt it's the most elegant solution. Using `git switch` immediately before `git reset --hard` can be inefficient if the two refer to different commits. I couldn't figure out an alternative and gave up though.

If you want to point me towards solutions for those caveats (and a repo I can test point 1 on) I can hack on this some more, but I certainly won't complain if you want to take what I have and polish it yourself either.

For a reproduction, you can check out my emacs.d here: https://gitlab.com/chasecaleb/emacs.d . You'll see that I'm using `maint` branch for `org` and `release` for `prettier`. Here's the difference that my fix makes:
```
caleb@arch-as-code-desktop> cd emacs.d-original/lib/prettier && git rev-parse HEAD && git status && cd -
e38d21a885e234af9ea6b03f499c487175570571
On branch master
Your branch and 'origin/master' have diverged,
and have 29 and 213 different commits each, respectively.
  (use "git pull" to merge the remote branch into yours)

nothing to commit, working tree clean
/tmp
caleb@arch-as-code-desktop> cd emacs.d-fixed/lib/prettier && git rev-parse HEAD && git status && cd -   
e38d21a885e234af9ea6b03f499c487175570571
On branch release
Your branch is up to date with 'origin/release'.

nothing to commit, working tree clean
/tmp
```

P.S. I made a few safety/lint fixes in a separate commit as well. If you haven't seen it before, https://www.shellcheck.net/ is an excellent shell linter. Feel free to rebase and drop the commit if you want to leave those as they were originally.