### PR TITLE
Modify `mtime` of the eln files after `make native-compile`

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -71,6 +71,12 @@
 (when (< emacs-major-version 26)
   (defun register-definition-prefixes (_file _prefixes)))
 
+(when (< emacs-major-version 28)
+  (defvar byte+native-compile)
+  (defvar comp-files-queue)
+  (defvar native-comp-eln-load-path)
+  (defvar native-compile-target-directory))
+
 (defvar git-commit-mode-map)
 (defvar compilation-mode-font-lock-keywords)
 
@@ -133,7 +139,9 @@ Set this in \"~/.emacs.d/etc/borg/config.el\" and also set
 \"~/.emacs.d/etc/borg/config.mk\" to the same value")
 
 (defvar borg-compile-function #'byte-compile-file
-  "The function used to compile a library.")
+  "The function used to compile a library.
+One of `byte-compile-file', `borg-byte+native-compile'
+or `borg-byte+native-compile-async'.")
 
 (defvar borg-compile-recursively nil
   "Whether to compile recursively.
@@ -145,6 +153,9 @@ needs it.")
 
 (defvar borg--compile-natively nil
   "Internal variable used by \"build-native\" make target.")
+
+(defvar borg-native-compile-deny-list nil
+  "List of file names to exclude files from native compilation.")
 
 (defvar borg-build-shell-command nil
   "Optional command used to run shell command build steps.
@@ -482,18 +493,19 @@ if it exists."
 (defun borg-batch-rebuild (&optional quick native)
   "Rebuild all assimilated drones.
 
-Borg and Compat are rebuild first, followed by other drones in
-alphabetic order.  `init.el' and `USER-REAL-LOGIN-NAME.el' are
-also rebuilt.
-
 This function is to be used only with `--batch'.
+
+Build Borg and Compat first, followed by all other drones in
+alphabetic order.  Finally build `init.el' and, if it exists,
+`USER-REAL-LOGIN-NAME.el'.
 
 When optional QUICK is non-nil, then do not build drones for
 which `submodule.DRONE.build-step' is set, assuming those are
 the drones that take longer to be built.
 
 When optional NATIVE is non-nil, then compile natively.  If
-NATIVE is a function, then use that, `native-compile' otherwise."
+NATIVE is a function, then use that, `borg-byte+native-compile'
+otherwise."
   (unless noninteractive
     (error "borg-batch-rebuild is to be used only with --batch"))
   (borg-do-drones (drone)
@@ -573,14 +585,18 @@ then also activate the clone using `borg-activate'."
     (when (file-exists-p config)
       (message "  Loading %s..." config)
       (load config nil t t))
-    (when (featurep 'comp)
+    (when (fboundp 'comp-ensure-native-compiler)
       (when borg--compile-natively
         (setq borg-compile-function
               (if (functionp borg--compile-natively)
                   borg--compile-natively
-                #'borg--native-compile)))
-      (when (eq borg-compile-function 'native-compile) ; don't #'quote
-        (setq borg-compile-function #'borg--native-compile)))
+                #'borg-byte+native-compile)))
+      (when (memq borg-compile-function '( borg--native-compile
+                                           native-compile
+                                           native-compile-async))
+        (message "WARNING: Using `%s' instead of unsuitable `%s'"
+                 'borg-byte+native-compile borg-compile-function)
+        (setq borg-compile-function #'borg-byte+native-compile)))
     (if build
         (dolist (cmd build)
           (message "  Running `%s'..." cmd)
@@ -794,6 +810,86 @@ then also activate the clone using `borg-activate'."
              (if (> skip-count 0) (format ", %d skipped" skip-count) "")
              (if (> dir-count  1) (format " in %d directories" dir-count) ""))))
 
+(defun borg-byte+native-compile (file)
+  (cond
+   ((or (equal (getenv "NATIVE_DISABLED") "1")
+        (member (file-name-nondirectory file)
+                borg-native-compile-deny-list))
+    (byte-compile-file file))
+   ((and (fboundp 'byte-write-target-file)
+         (fboundp 'comp--native-compile)
+         (fboundp 'comp-ensure-native-compiler))
+    (comp-ensure-native-compiler)
+    (let* ((byte+native-compile t)
+           (byte-to-native-output-buffer-file nil)
+           (native-compile-target-directory (car native-comp-eln-load-path))
+           (eln-file (comp--native-compile file)))
+      (pcase byte-to-native-output-buffer-file
+        (`(,temp-buffer . ,target-file)
+         (unwind-protect
+             (progn
+               (byte-write-target-file temp-buffer target-file)
+               (when (stringp eln-file)
+                 (set-file-times eln-file)))
+           (kill-buffer temp-buffer)
+           (file-exists-p target-file))))))
+   ((error "Emacs %s does not support native compilation" emacs-version))))
+
+(defun borg-byte+native-compile-async (file)
+  (byte-compile-file file)
+  (cond
+   ((fboundp 'native-compile-async)
+    (native-compile-async file))
+   ((error "Emacs %s does not support native compilation" emacs-version))))
+
+(defun borg--batch-native-compile ()
+  (cond
+   ((and (fboundp 'comp-ensure-native-compiler)
+         (fboundp 'comp-run-async-workers))
+    (comp-ensure-native-compiler)
+    (borg-do-drones (drone)
+      (unless (or (equal (borg-get drone "disabled") "true")
+                  (let ((min (cdr (assoc drone borg-minimal-emacs-alist))))
+                    (and min (version< emacs-version min)))
+                  (not (file-exists-p (borg-worktree drone))))
+        (let ((dirs (borg--expand-load-path drone nil))
+              (exclude (borg-get-all drone "no-byte-compile"))
+              (topdir (borg-worktree drone))
+              (default-directory borg-user-emacs-directory)
+              (dir nil))
+          (while (setq dir (pop dirs))
+            (dolist (file (directory-files dir t))
+              (let ((name (file-name-nondirectory file)))
+                (cond
+                 ((member (file-relative-name file topdir) exclude))
+                 ((and (file-directory-p file)
+                       (if-let ((v (borg-get drone "recursive-byte-compile")))
+                           (member v '("yes" "on" "true" "1"))
+                         borg-compile-recursively)
+                       (not (or (file-symlink-p file)
+                                (string-prefix-p "." name)
+                                (member name '("RCS" "CVS"))
+                                (file-exists-p
+                                 (expand-file-name ".nosearch" file)))))
+                  (setq dirs (nconc dirs (list file))))
+                 ((and (file-regular-p file)
+                       (file-readable-p file)
+                       (string-match-p emacs-lisp-file-regexp name)
+                       (not (or (auto-save-file-name-p file)
+                                (string-prefix-p "." name)
+                                (string-suffix-p "-autoloads.el" name)
+                                (string-equal dir-locals-file name)
+                                (string-suffix-p "-pkg.el" name)
+                                (string-suffix-p "-test.el" name)
+                                (string-suffix-p "-tests.el" name))))
+                  (push (list file) comp-files-queue)))))))))
+    (message "Natively compiling %s libraries" (length comp-files-queue))
+    (setq comp-files-queue (nreverse comp-files-queue))
+    (comp-run-async-workers)
+    (add-hook 'native-comp-async-all-done-hook #'kill-emacs)
+    (sit-for 999999999 t))
+   ((error "Emacs %s does not support native compilation" emacs-version))))
+
 (defun borg-maketexi (clone &optional files)
   "Generate Texinfo manuals from Org files for the clone named CLONE.
 Export each file located on `borg-info-path' if its name matches
@@ -874,11 +970,6 @@ doesn't do anything."
                      dir t "\\(\\.elc\\|-autoloads\\.el\\|-loaddefs\\.el\\)\\'"
                      t))
         (ignore-errors (delete-file file))))))
-
-(defun borg--native-compile (file)
-  (with-demoted-errors "borg--native-compile: %S"
-    (when (fboundp 'native-compile)
-      (native-compile file))))
 
 ;;; Assimilation
 

--- a/borg.el
+++ b/borg.el
@@ -151,7 +151,7 @@ into subdirectories.  Instead of this variable you should set
 `submodule.<drone>.recursive-byte-compile' for each DRONE that
 needs it.")
 
-(defvar borg-native-compile-deny-list nil
+(defvar borg-native-compile-deny-list '("yaml.el")
   "List of file names to exclude files from native compilation.")
 
 (defvar borg-build-shell-command nil

--- a/borg.mk
+++ b/borg.mk
@@ -43,8 +43,10 @@ help::
 	$(info make quick           = byte-compile most drones and init files)
 ifeq "$(BORG_SECONDARY_P)" "true"
 	$(info make $(DRONES_DIR)/DRONE      = byte-compile DRONE)
+	$(info make native/DRONE      = byte+native-compile DRONE)
 else
 	$(info make $(DRONES_DIR)/DRONE       = byte-compile DRONE)
+	$(info make native/DRONE       = byte+native-compile DRONE)
 endif
 	$(info make build-native    = byte+native-compile all drones and init files)
 	$(info make native-compile  = native-compile all drones)
@@ -97,10 +99,16 @@ quick: clean-init
 	--eval '(borg-batch-rebuild t)' 2>&1
 
 $(BORG_DIR)borg.mk: ;
+
 $(DRONES_DIR)/%: .FORCE
 	@$(EMACS) $(EMACS_ARGUMENTS) $(EMACS_EXTRA) $(SILENCIO) \
 	$(BORG_ARGUMENTS) \
 	--eval '(borg-build "$*")' 2>&1
+
+native/%: .FORCE
+	@$(EMACS) $(EMACS_ARGUMENTS) $(EMACS_EXTRA) $(SILENCIO) \
+	$(BORG_ARGUMENTS) \
+	--eval '(borg-build "$*" nil t)' 2>&1
 
 bootstrap:
 	@printf "\n=== Running 'git submodule init' ===\n\n"

--- a/borg.mk
+++ b/borg.mk
@@ -39,18 +39,19 @@ SILENCIO += --eval "(fset 'message\
     (apply 'original-message format args))))"
 
 help::
-	$(info make [all|build]     = rebuild all drones and init files)
-	$(info make quick           = rebuild most drones and init files)
+	$(info make [all|build]     = byte-compile all drones and init files)
+	$(info make quick           = byte-compile most drones and init files)
 ifeq "$(BORG_SECONDARY_P)" "true"
-	$(info make $(DRONES_DIR)/DRONE      = rebuild DRONE)
+	$(info make $(DRONES_DIR)/DRONE      = byte-compile DRONE)
 else
-	$(info make $(DRONES_DIR)/DRONE       = rebuild DRONE)
+	$(info make $(DRONES_DIR)/DRONE       = byte-compile DRONE)
 endif
-	$(info make build-native    = rebuild drones natively and init files)
-	$(info make build-init      = rebuild init files)
+	$(info make build-native    = byte+native-compile all drones and init files)
+	$(info make native-compile  = native-compile all drones)
+	$(info make build-init      = byte-compile init files)
 	$(info make tangle-init     = recreate init.el from init.org)
 	$(info make clean           = remove all byte-code files)
-	$(info make clean-init      = remove init files)
+	$(info make clean-init      = remove init byte-code files)
 ifneq "$(BORG_SECONDARY_P)" "true"
 	$(info make bootstrap-borg  = bootstrap borg itself)
 endif
@@ -68,11 +69,16 @@ build: clean-init
 	$(BORG_ARGUMENTS) \
 	--funcall borg-batch-rebuild $(INIT_FILES) 2>&1
 
-build-native:
+build-native: clean-init
 	@$(EMACS) $(EMACS_ARGUMENTS) $(EMACS_EXTRA) $(SILENCIO) \
 	$(BORG_ARGUMENTS) \
-	--eval "(borg-batch-rebuild nil 'native-compile-async)" \
+	--eval "(borg-batch-rebuild nil 'borg-byte+native-compile)" \
 	$(INIT_FILES) 2>&1
+
+native-compile:
+	@$(EMACS) $(EMACS_ARGUMENTS) $(EMACS_EXTRA) $(SILENCIO) \
+	$(BORG_ARGUMENTS) \
+	--eval "(borg--batch-native-compile)" 2>&1
 
 build-init: clean-init
 	@$(EMACS) $(EMACS_ARGUMENTS) $(EMACS_EXTRA) \

--- a/docs/borg.org
+++ b/docs/borg.org
@@ -755,16 +755,16 @@ which is part of the ~borg~ package.
 - Command: all ::
 - Command: build ::
 
-  This target rebuilds all assimilated drones in alphabetic order,
-  except for Org which is rebuilt first.  After that it also builds
+  These targets byte-compiles Borg and Compat first, followed by all
+  other drones in alphabetic order.  After that it also byte-compiles
   the user init files, like ~build-init~ does.
 
 - Command: build-init ::
 
-  This target builds the init files specified by the Make variable
-  ~INIT_FILES~, or if that is unspecified ~init.el~ and ~LOGIN.el~, where
-  ~LOGIN~ is the value of the variable ~user-real-login-name~.  If a file
-  does not exist, then it is silently ignored.
+  This target byte-compiles the init files specified by the make
+  variable ~INIT_FILES~; or if that is unspecified ~init.el~ and ~LOGIN.el~
+  (where ~LOGIN~ is the value of the variable ~user-real-login-name~).
+  If an init file does not exist, then that is silently ignored.
 
   If you publish your ~~/.emacs.d~ repository but would like to keep
   some settings private, then you can do so by putting them in a file
@@ -783,6 +783,23 @@ which is part of the ~borg~ package.
 - Command: lib/DRONE ::
 
   This target builds the drone named DRONE.
+
+- Command: build-native ::
+
+  This target byte-compiles and natively compiles all drones
+  synchronously.  Then it also byte-compiles all user init files.
+
+- Command: native-compile ::
+
+  This target compiles all drones natively.  It doesn't byte-compile
+  them and it doesn't compile any init files and therefore has to be
+  explicitly used in combination with the ~build~ target.  Unlike when
+  using ~build-native~, you don't have to wait for native compilation to
+  complete before you can launch Emacs:
+
+  #+begin_src undefined
+    make clean build ; emacs & ; make native-compile
+  #+end_src
 
 - Command: tangle-init ::
 
@@ -1017,18 +1034,22 @@ variables you can tell Borg how to build such packages.
 
 - Variable: borg-compile-function ::
 
-  Setting this variable to ~native-compile~ enables native compilation.
-  This can be done in ~/.emacs.d/etc/borg/config.el~.
+  The function used to compile each individual library.
+  One of ~byte-compile-file~, ~borg-byte+native-compile~ or
+  ~borg-byte+native-compile-async~.
 
-  #+begin_src emacs-lisp
-    (when (native-comp-available-p)
-      (setq borg-compile-function #'native-compile))
-  #+end_src
+  To enable native compilation when running ~make~, use one of the
+  respective make targets, as described in [[*Make targets]].
 
 - Variable: borg-compile-recursively ::
 
   Setting this variable to a non-nil value instructs ~borg-compile~
   to compile all drones recursively.  Doing so is discouraged.
+
+- Variable: borg-native-compile-deny-list ::
+
+  This variable lists the names of files to be excluded from native
+  compilation.
 
 - Variable: submodule.DRONE.info-path PATH ::
 


### PR DESCRIPTION
Hi,

## TL; DR:
Modify `mtime` of the eln files to ensure that the eln can be loaded rather than recompiled by Emacs after `make native-compile`.

## The long version:
Before loading the `.eln` file, Emacs will determine the `mtime` of the elc and eln files. If the eln was created earlier then elc, the eln file will be recompiled.

After upgrading DRONES, `make lib/DRONE` recompiled all el files to generate elc, and `make native-compile` recompiled the **changed el files** to generate eln. So for a DRONE like "magit" that contains multiple el files, all elc files will be updated, but not all eln files will be updated. The eln files are correctly, but when we use "magit" in Emacs, due to `mtime`, Emacs will decide that these eln files are out of data and it will recompile them.

So a better way is to modify the `mtime` of the eln files after `make native-compile`, which is what this PR is for.