### PR TITLE
Don't assume epkg is available

### DIFF
--- a/borg-elpa.el
+++ b/borg-elpa.el
@@ -63,7 +63,7 @@
                          nil))) ; Just hope that it is installed using elpa.
                    '("emacsql" "closql" "epkg"))
                   load-path)))
-      (require (quote epkg))))
+      (require (quote epkg) nil t)))
   (borg-initialize)
   (package-initialize))
 
@@ -80,7 +80,7 @@
   "For a Borg-installed package, use information from the Epkgs database."
   (if-let ((dir (package--borg-clone-p pkg-dir)))
       (let* ((name (file-name-nondirectory (directory-file-name dir)))
-             (epkg (epkg name))
+             (epkg (and (fboundp 'epkg) (epkg name)))
              (desc (package-process-define-package
                     (list 'define-package
                           name
@@ -88,7 +88,10 @@
                           (if epkg
                               (or (oref epkg summary)
                                   "[No summary]")
-                            "[Installed using Borg, but not in Epkgs database]")
+                            (format "[Installed using Borg, but %s]"
+                                    (if (featurep 'epkg)
+                                        "not in Epkgs database"
+                                      "Epkg database not available")))
                           ()))))
         (setf (package-desc-dir desc) pkg-dir)
         desc)


### PR DESCRIPTION
I'm not sure this is the correct solution, but M-x borg-build has been
failing recently because I don't have epkg installed.  This commit
modifies `borg-elpa-initialize` and
`package-load-descriptor--borg-use-database` so they don't assume epkg
is installed.

Here's an example of the aforementioned error:

```
(17:51:28) Building borg

Package autoload is deprecated
Cannot open load file: No such file or directory, epkg

Error: file-missing ("Cannot open load file" "No such file or directory" "epkg")
  debug-early-backtrace()
  debug-early(error (file-missing "Cannot open load file" "No such file or directory" "epkg"))
  require(epkg)
  (let ((load-path (nconc (cl-mapcan #'(lambda (name) (let ((dir (expand-file-name name borg-drones-directory))) (if (file-directory-p dir) (list dir) nil))) '("emacsql" "closql" "epkg")) load-path))) (require 'epkg))
  (if (featurep 'epkg) nil (let ((load-path (nconc (cl-mapcan #'(lambda (name) (let ((dir (expand-file-name name borg-drones-directory))) (if (file-directory-p dir) (list dir) nil))) '("emacsql" "closql" "epkg")) load-path))) (require 'epkg)))
  borg-elpa-initialize()
  (progn (setq user-emacs-directory "/home/thblt/.emacs.d/") (require 'package) (package-initialize 'no-activate) (package-activate 'borg) (require 'borg-elpa) (borg-elpa-initialize) (setq borg-build-shell-command 'nil) (borg-build "borg"))
  command-line-1(("-L" "/home/thblt/.emacs.d/lib/borg/" "--eval" "(progn\n  (setq user-emacs-directory \"/home/thblt/.emacs.d/\")\n  (require 'package)\n  (package-initialize 'no-activate)\n  (package-activate 'borg)\n  (require 'borg-elpa)\n  (borg-elpa-initialize)\n  (setq borg-build-shell-command (quote nil))\n  (borg-build \"borg\"))"))
  command-line()
  normal-top-level()

Process emacs ... --eval (borg-build "borg") exited abnormally with code 255
```

Thanks!