### PR TITLE
Update "Bootstrapping from scratch" docs

### DIFF
--- a/docs/borg.org
+++ b/docs/borg.org
@@ -248,6 +248,7 @@ so lets manually install that and its dependency first:
   git submodule add --name closql git@github.com:emacscollective/closql.git lib/closql
   git submodule add --name emacsql git@github.com:skeeto/emacsql.git lib/emacsql
   git submodule add --name compat https://git.sr.ht/~pkal/compat lib/compat
+  git submodule add --name llama https://git.sr.ht/~tarsius/llama lib/llama
   git submodule add --name epkg git@github.com:emacscollective/epkg.git lib/epkg
   git config -f .gitmodules submodule.emacsql.no-byte-compile emacsql-pg.el
   echo /epkgs/ >> .gitignore

--- a/docs/borg.texi
+++ b/docs/borg.texi
@@ -331,6 +331,7 @@ so lets manually install that and its dependency first:
 git submodule add --name closql git@@github.com:emacscollective/closql.git lib/closql
 git submodule add --name emacsql git@@github.com:skeeto/emacsql.git lib/emacsql
 git submodule add --name compat https://git.sr.ht/~pkal/compat lib/compat
+git submodule add --name llama https://git.sr.ht/~tarsius/llama lib/llama
 git submodule add --name epkg git@@github.com:emacscollective/epkg.git lib/epkg
 git config -f .gitmodules submodule.emacsql.no-byte-compile emacsql-pg.el
 echo /epkgs/ >> .gitignore


### PR DESCRIPTION
Adds `git submodule add` command for `llama` in "Bootstrapping from scratch" section since epkg uses llama as of 784b876. Without this change epkg will fail to build or run when bootstrapping from scratch.
