### PR TITLE
make: Don't use Q, allow the use of site-lisp

### DIFF
--- a/borg.mk
+++ b/borg.mk
@@ -22,7 +22,7 @@ else
 endif
 
 EMACS           ?= emacs
-EMACS_ARGUMENTS ?= -Q --batch
+EMACS_ARGUMENTS ?= --batch
 
 EMACS_EXTRA ?=
 


### PR DESCRIPTION
The rationale is that some Emacs packages might be found in site-lisp,
especially as for other packages such as those that would require
native modules.