### PR TITLE
Use $(MAKE) variable in `build` target

### DIFF
--- a/borg.mk
+++ b/borg.mk
@@ -165,6 +165,6 @@ bootstrap:
 	@printf "\n=== Running '$(BORG_DIR)borg.sh checkout' ===\n"
 	@$(BORG_DIR)borg.sh checkout --reset-hard
 	@printf "\n=== Running 'make build' ===\n\n"
-	@make build
+	@$(MAKE) build
 	@printf "\n=== Bootstrapping finished ===\n\n"
 	@git submodule status


### PR DESCRIPTION
This is so that platforms with non-GNU Make (*BSD, etc.) won't fail during bootstrapping/building

