### PR TITLE
borg-activate: Extend load-path before loading autoloads

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -483,15 +483,13 @@ if it exists."
   (cl-flet
       ((activate (dir part)
          (let ((file (expand-file-name (format "%s-%s.el" clone part) dir)))
-           (and (file-exists-p file)
-                (with-demoted-errors "Error loading autoloads: %s"
-                  (load file nil t))
-                ;; We cannot rely on the autoloads file doing that.
-                (add-to-list 'load-path dir)))))
+           (when (file-exists-p file)
+             (with-demoted-errors "Error loading autoloads: %s"
+               (load file nil t))))))
     (dolist (dir (borg-load-path clone))
+      (add-to-list 'load-path dir)
       (or (activate dir "autoloads")
-          (activate dir "loaddefs")       ; `org' uses a different name.
-          (add-to-list 'load-path dir)))) ; There might be no autoloads file.
+          (activate dir "loaddefs"))))    ; `org' uses a different name.
   (dolist (dir (borg-info-path clone))
     (push  dir Info-directory-list)))
 


### PR DESCRIPTION
This changes `borg-activate` to extend `load-path` always and unconditionally before loading autoloads.

The current code only extends `load-path` _after_ loading the autoloads, and it does that also in a bit of a redundant way. Once as part of the local `activate` function and then again outside as a fallback.

edit: Sorry, I just realize I didn't motivate this PR. I tried to load [el-patch](https://github.com/radian-software/el-patch) with borg. That package emits a `(require 'el-patch-stub)` into its autoloads file (see [`el-patch.el`](https://github.com/radian-software/el-patch/blob/92803e7ea6e07cd56667ed7ea0dfacfc1f37f6d9/el-patch.el#L818)). This then fails when borg tries to load the autoloads file. While that may be unconventional (?), it still seems reasonable to me to assume that a package is in `load-path` before its autoload file is evaluated.