### PR TITLE
bork.mk: Make sure init.el is tangled before init-build if init.org exists

### DIFF
--- a/borg.mk
+++ b/borg.mk
@@ -158,6 +158,10 @@ init-build: init-clean
 	$(BORG_ARGUMENTS) \
 	--funcall borg-batch-rebuild-init $(INIT_FILES) 2>&1
 
+ifeq ($(wildcard init.org), init.org)
+init-build: init.el
+endif
+
 ## Bootstrap
 
 bootstrap:

--- a/borg.mk
+++ b/borg.mk
@@ -147,8 +147,8 @@ native/%: .FORCE
 init-clean:
 	$(Q)rm -f init.elc $(INIT_FILES:.el=.elc)
 
-init-tangle: init.el
-init.el: init.org
+init-tangle: init.org
+	@printf "%s\n" "--- [init.org] ---"
 	$(Q)$(EMACS) $(EMACS_ARGUMENTS) $(EMACS_EXTRA) \
 	--load org \
 	--eval '(org-babel-tangle-file "init.org")' 2>&1
@@ -159,7 +159,7 @@ init-build: init-clean
 	--funcall borg-batch-rebuild-init $(INIT_FILES) 2>&1
 
 ifeq ($(wildcard init.org), init.org)
-init-build: init.el
+init-build: init-tangle
 endif
 
 ## Bootstrap

--- a/docs/borg.org
+++ b/docs/borg.org
@@ -750,11 +750,6 @@ those are the drones that take longer to build.
   This target tangles (creates) ~init.el~ from ~init.org~.  You obviously
   don't have to use such a file, if you don't want to.
 
-  Note that this target is *not* a dependency of ~init-build~, because it
-  necessarily has to depend on ~init.org~, which for most people does
-  not exist.  So you have to run this target explicitly after making
-  changes to ~init.org~.
-
 - Command: init-build ::
 
   This target byte-compiles the init files specified by the make

--- a/docs/borg.texi
+++ b/docs/borg.texi
@@ -831,11 +831,6 @@ This target removes byte-code files for init files.
 @deffn Command init-tangle
 This target tangles (creates) @code{init.el} from @code{init.org}.  You obviously
 don't have to use such a file, if you don't want to.
-
-Note that this target is @strong{not} a dependency of @code{init-build}, because it
-necessarily has to depend on @code{init.org}, which for most people does
-not exist.  So you have to run this target explicitly after making
-changes to @code{init.org}.
 @end deffn
 
 @deffn Command init-build


### PR DESCRIPTION
Partially revert 2628c68fa91c35ce7b9cfb1e637fd397dda6621f and add
optional dependency for init-build to init.el

Like #162 but better.