### PR TITLE
Fix emacs 31.1 warnings

### DIFF
--- a/borg-elpa.el
+++ b/borg-elpa.el
@@ -76,7 +76,7 @@
 
 (define-advice package-load-descriptor (:around (fn pkg-dir) borg-use-database)
   "For a Borg-installed package, use information from the Epkgs database."
-  (if-let ((dir (package--borg-clone-p pkg-dir)))
+  (if-let* ((dir (package--borg-clone-p pkg-dir)))
       (let* ((name (file-name-nondirectory (directory-file-name dir)))
              (epkg (and (fboundp 'epkg) (epkg name)))
              (desc (package-process-define-package

--- a/borg.el
+++ b/borg.el
@@ -631,7 +631,7 @@ and optional NATIVE are both non-nil, then also compile natively."
         (borg-compile clone path)
         (borg-maketexi clone)
         (borg-makeinfo clone)))
-    (when-let ((commands
+    (when-let* ((commands
                 (borg--module-config "--get-all" "borg.extra-build-step")))
       (borg--run-build-commands clone commands build-cmd))))
 
@@ -813,7 +813,7 @@ and optional NATIVE are both non-nil, then also compile natively."
                   ((symbol-function 'progress-reporter-done) (lambda (_))))
           (let ((generated-autoload-file file))
             (apply 'update-directory-autoloads path))))))
-    (when-let ((buf (find-buffer-visiting file)))
+    (when-let* ((buf (find-buffer-visiting file)))
       (kill-buffer buf))))
 
 (defun borg-compile (clone &optional path)
@@ -1129,7 +1129,7 @@ The Git directory is not removed."
   "Insert information about drones that are changed in the index.
 Formatting is according to the commit message conventions."
   (interactive)
-  (when-let ((alist (borg--drone-states)))
+  (when-let* ((alist (borg--drone-states)))
     (let ((width (apply #'max (mapcar (lambda (e) (length (car e))) alist)))
           (align (cl-member-if (pcase-lambda (`(,_ ,_ ,version))
                                  (and version

--- a/borg.el
+++ b/borg.el
@@ -624,7 +624,7 @@ and optional NATIVE are both non-nil, then also compile natively."
         (config (borg--config-file)))
     (when (file-exists-p config)
       (load config nil t t))
-    (if-let ((commands (borg-get-all clone "build-step")))
+    (if-let* ((commands (borg-get-all clone "build-step")))
         (borg--run-build-commands clone commands build-cmd)
       (let ((path (mapcar #'file-name-as-directory (borg-load-path clone))))
         (borg-update-autoloads clone path)
@@ -834,7 +834,7 @@ and optional NATIVE are both non-nil, then also compile natively."
          (let ((file-relative (file-relative-name file topdir))
                (name (file-name-nondirectory file)))
            (if (file-directory-p file)
-               (when (and (if-let ((v (borg-get
+               (when (and (if-let* ((v (borg-get
                                        clone "recursive-byte-compile")))
                               (member v '("yes" "on" "true" "1"))
                             borg-compile-recursively)

--- a/borg.mk
+++ b/borg.mk
@@ -38,7 +38,7 @@ EMACS_EXTRA ?=
 
 SILENCIO += --eval "(progn (require 'gv) (put 'buffer-substring 'byte-obsolete-generalized-variable nil))"
 SILENCIO += --eval "(progn \
-  (put 'if-let 'byte-obsolete-info nil) \
+  (put 'if-let* 'byte-obsolete-info nil) \
   (put 'when-let 'byte-obsolete-info nil))"
 SILENCIO += --eval "(define-advice message (:around (fn format &rest args) silencio)\
   (unless (or (equal format \"Not registering prefix \\\"%s\\\" from %s.  Affects: %S\")\

--- a/borg.mk
+++ b/borg.mk
@@ -39,7 +39,7 @@ EMACS_EXTRA ?=
 SILENCIO += --eval "(progn (require 'gv) (put 'buffer-substring 'byte-obsolete-generalized-variable nil))"
 SILENCIO += --eval "(progn \
   (put 'if-let* 'byte-obsolete-info nil) \
-  (put 'when-let 'byte-obsolete-info nil))"
+  (put 'when-let* 'byte-obsolete-info nil))"
 SILENCIO += --eval "(define-advice message (:around (fn format &rest args) silencio)\
   (unless (or (equal format \"Not registering prefix \\\"%s\\\" from %s.  Affects: %S\")\
               (ignore-errors (string-match-p \"Scraping files for\" (car args))))\

--- a/default.mk
+++ b/default.mk
@@ -18,8 +18,8 @@ REVDESC := $(shell test -e $(TOP).git && git describe --tags)
 
 EMACS      ?= emacs
 EMACS_ARGS ?= --eval "(progn \
-  (put 'if-let 'byte-obsolete-info nil) \
-  (put 'when-let 'byte-obsolete-info nil))"
+  (put 'if-let* 'byte-obsolete-info nil) \
+  (put 'when-let* 'byte-obsolete-info nil))"
 
 LOAD_PATH  ?= $(addprefix -L ../,$(DEPS))
 LOAD_PATH  += -L .


### PR DESCRIPTION
Since emacs 31.1, `if-let` and `when-let` are obsolete.
This pull request replaces them by `if-let*` and `when-let*`.