### PR TITLE
Add update-modules target to update them without detaching them

### DIFF
--- a/borg.mk
+++ b/borg.mk
@@ -208,3 +208,6 @@ clone-modules:
 
 checkout-modules:
 	$(Q)$(BORG_DIR)borg.sh checkout
+
+update-modules:
+	$(Q)$(BORG_DIR)borg.sh checkout --force

--- a/borg.sh
+++ b/borg.sh
@@ -186,7 +186,8 @@ checkout () {
             echo "Skipping $path (always using latest/checked out borg)"
             echo "    HEAD: $head"
             echo "expected: $hash"
-        elif [ -n "$(git status --porcelain=v1)" ]
+        elif [ -n "$(git status --porcelain=v1 --untracked-files=no)" ]
+             # FIXME: How should untracked changes be addressed here such i.e. Info dirs?
         then
             echo "Skipping $path (uncommitted changes)"
             echo "    HEAD: $head"

--- a/borg.sh
+++ b/borg.sh
@@ -160,8 +160,10 @@ clone () {
 checkout () {
     path="$1"
     shift
-    force="$1"
-    shift
+    if [ $# -ge 1 ] ; then
+        force="$1"
+        shift
+    fi
     echo "--- [$path] ---"
 
     cd "$super"
@@ -249,7 +251,7 @@ cmd_checkout () {
 
     if [ $# -ne 0 ]
     then
-        for path in "$@"; do checkout $path $force; done
+        for path in "$@"; do checkout $path ${force+ $force}; done
     else
         git ls-files -s | grep ^160000 | cut -f2 |
             while read path; do checkout $path $force; done

--- a/borg.sh
+++ b/borg.sh
@@ -197,6 +197,11 @@ checkout () {
             echo "Skipping $path (tip no longer matches upstream)"
             echo "    HEAD: $head"
             echo "expected: $hash"
+        elif [ "${force:-nil}" = t ] && [ -z "$branch" ]
+             # FIXME: Check if the current branch matches the upstreams
+             # head or git the submodules branch variable
+        then
+            echo "HEAD is in detached state, expected a branch"
         else
             echo "Checkout $path ($hash)"
             echo "HEAD was $(git log --no-walk --format='%h %s' HEAD)"

--- a/borg.sh
+++ b/borg.sh
@@ -256,9 +256,9 @@ cmd_checkout () {
     fi
 }
 
-command=$1
+command=${1:-nil}
 
-case "$command" in
+case "${command}" in
     clone|checkout) shift; "cmd_$command" "$@" ;;
     *) usage ;;
 esac


### PR DESCRIPTION
Like git submodule update --checkout but without detaching them.
Reuses the existing borg.sh checkout command but resets it to the
target commit without checking if the branch matches to said target
commit, just like git submodule --checkout.

Relates to #176.

There are no manual changes in this PR as I'm first waiting for feedback.