### PR TITLE
Fix drone state computation when the Emacs directory is not git root

### DIFF
--- a/borg.el
+++ b/borg.el
@@ -1236,7 +1236,7 @@ Formatting is according to the commit message conventions."
           version))))))
 
 (defun borg--drone-states ()
-  (let ((default-directory borg-user-emacs-directory))
+  (let ((default-directory borg-top-level-directory))
     (mapcar
      (lambda (line)
        (pcase-let ((`(,state ,module) (split-string line "\t")))


### PR DESCRIPTION
`git diff-index` emits a path relative to root.  If root differed from
`borg-user-emacs-directory`, `(expand-file-name module)` expanded to
the wrong path.  This led to the version always being REMOVE on
`borg-insert-update-message` if the Emacs directory was not the same
as the git directory.

This pull request instead sets default directory in the drone state
computation to `borg-top-level-directory`.